### PR TITLE
Pull crypto-js from NPM instead of bower

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ You can also import hash methods directly:
 or
 `import SHA3 from 'cryptojs/sha3'`
 
-
-## TODO:
-  - [ ] ES6 Modules for remaining cryptojs components.
-  - [ ] Test has options
-  - [ ] Import from NPM instead of Bower (if anyone knows how to do this I would love to hear about it)
-
 ## For developers
 
 ### Installation

--- a/blueprints/ember-cryptojs-shim/index.js
+++ b/blueprints/ember-cryptojs-shim/index.js
@@ -5,7 +5,8 @@ module.exports = {
     // because ember cli normally expects the format
     // ember generate <entityName> <blueprint>
   },
-  afterInstall: function(options) {
-    return this.addBowerPackageToProject('crypto-js');
+
+  afterInstall: function() {
+    return this.addPackageToProject('crypto-js', '^3.1.0');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "ember": "~2.7.0",
     "ember-cli-shims": "0.1.1",
-    "ember-qunit-notifications": "0.1.0",
-    "crypto-js": "^3.1.6"
+    "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,12 +1,27 @@
 /* jshint node: true */
 'use strict';
 
+var path = require('path');
+var resolve = require('resolve');
+var Funnel = require('broccoli-funnel');
+var MergeTrees = require('broccoli-merge-trees');
+
 module.exports = {
   name: 'ember-cryptojs-shim',
   included: function included(app) {
-    this._super.included(app);
-    app.import(app.bowerDirectory + '/crypto-js/crypto-js.js');
-    app.import('vendor/cryptojs.js', {
+    this._super.included.apply(this, arguments);
+
+    var importContext;
+    if (this.import) {
+      // support for ember-cli >= 2.7
+      importContext = this;
+    } else {
+      // addon support for ember-cli < 2.7
+      importContext = this._findHostForLegacyEmberCLI();
+    }
+
+    importContext.import('vendor/crypto-js/crypto-js.js');
+    importContext.import('vendor/cryptojs.js', {
       exports: {
         CryptoJS: [
           'default',
@@ -25,5 +40,34 @@ module.exports = {
         ]
       }
     });
+  },
+
+  treeForVendor: function(tree) {
+    var cryptojsPath = path.dirname(resolve.sync('crypto-js'));
+    var cryptoJsTree = new Funnel(cryptojsPath, {
+      files: ['crypto-js.js'],
+      destDir: '/crypto-js',
+    });
+
+    var trees = [tree, cryptoJsTree];
+
+    return new MergeTrees(trees, {
+      annotation: 'ember-cryptojs-shim: treeForVendor'
+    });
+  },
+
+  // included from https://git.io/v6F7n
+  // not needed for ember-cli > 2.7
+  _findHostForLegacyEmberCLI: function() {
+    var current = this;
+    var app;
+
+    // Keep iterating upward until we don't have a grandparent.
+    // Has to do this grandparent check because at some point we hit the project.
+    do {
+      app = current.app || app;
+    } while (current.parent.parent && (current = current.parent));
+
+    return app;
   }
 };

--- a/package.json
+++ b/package.json
@@ -63,7 +63,11 @@
     "Base64"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "broccoli-funnel": "^1.1.0",
+    "broccoli-merge-trees": "^1.2.1",
+    "crypto-js": "^3.1.8",
+    "ember-cli-babel": "^5.1.6",
+    "resolve": "^1.1.7"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/vendor/cryptojs.js
+++ b/vendor/cryptojs.js
@@ -1,5 +1,5 @@
 (function() {
-  /* globals define, chartist */
+  /* globals define, CryptoJS */
 
   function generateModule(name, values) {
     define(name, [], function() {


### PR DESCRIPTION
It is now possible to grab ths library out of NPM.  This is a good idea since bower makes everyone sad.