### PR TITLE
Add `useYarn` flag to `ember-try` configuration

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 module.exports = {
+  useYarn: true,
   scenarios: [
     {
       name: 'ember-lts-2.8',


### PR DESCRIPTION
This fixes the broken Ember 2.12 tests.